### PR TITLE
Change application ls to list

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -69,7 +69,7 @@ $ chor version
 ### chor application
 
 `application` command is used to manage applications created with the Choreo platform. 
-Available sub commands include [create](#chor-application-create) and [ls](#chor-application-ls).
+Available sub commands include [create](#chor-application-create) and [list](#chor-application-list).
 
 #### Synopsis
 


### PR DESCRIPTION
## Purpose
> We changed `chor application ls` to `chor applicaiton list`. Therefore changing the docs for that.
